### PR TITLE
MINOR: forwardfor: remove NoOption

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -180,11 +180,10 @@ type Mailer struct {
 //test:fail:option forwardfor except A header
 //test:fail:option forwardfor header
 type OptionForwardFor struct {
-	NoOption bool
-	Except   string
-	Header   string
-	IfNone   bool
-	Comment  string
+	Except  string
+	Header  string
+	IfNone  bool
+	Comment string
 }
 
 //sections:defaults, backend


### PR DESCRIPTION
NoOption is not viable for ```forwardfor```: https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#option%20forwardfor

And it is not used in parsers, so removing it.