### PR TITLE
BUG/MEDIUM: panic when parsing option httpchk

### DIFF
--- a/parsers/option-httpchk.go
+++ b/parsers/option-httpchk.go
@@ -40,8 +40,7 @@ func (s *OptionHttpchk) Parse(line string, parts, previousParts []string, commen
 			s.data = &types.OptionHttpchk{
 				Comment: comment,
 			}
-		}
-		if len(parts) == 3 {
+		} else if len(parts) == 3 {
 			s.data = &types.OptionHttpchk{
 				Uri:     parts[2],
 				Comment: comment,


### PR DESCRIPTION
When parsing option httpchk you would get a panic Slice index out
of bounds, because there was a missing else if.