### PR TITLE
BUG/MINOR: use_backend without condition

### DIFF
--- a/parsers/use-backend.go
+++ b/parsers/use-backend.go
@@ -30,7 +30,7 @@ type UseBackend struct {
 }
 
 func (h *UseBackend) parse(line string, parts []string, comment string) (*types.UseBackend, error) {
-	if len(parts) >= 4 {
+	if len(parts) >= 2 {
 		_, condition := common.SplitRequest(parts[2:])
 		data := &types.UseBackend{
 			Name:    parts[1],

--- a/tests/use_backend_generated_test.go
+++ b/tests/use_backend_generated_test.go
@@ -68,6 +68,27 @@ func TestUseBackendNormal1(t *testing.T) {
 		t.Errorf(fmt.Sprintf("error: has [%s] expects [%s]", returnLine, line))
 	}
 }
+func TestUseBackendNormal2(t *testing.T) {
+	parser := &parsers.UseBackend{}
+	line := strings.TrimSpace("use_backend test # deny")
+	err := ProcessLine(line, parser)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	result, err := parser.Result()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	var returnLine string
+	if result[0].Comment == "" {
+		returnLine = fmt.Sprintf("%s", result[0].Data)
+	} else {
+		returnLine = fmt.Sprintf("%s # %s", result[0].Data, result[0].Comment)
+	}
+	if line != returnLine {
+		t.Errorf(fmt.Sprintf("error: has [%s] expects [%s]", returnLine, line))
+	}
+}
 func TestUseBackendFail0(t *testing.T) {
 	parser := &parsers.UseBackend{}
 	line := strings.TrimSpace("use_backend")

--- a/types/types.go
+++ b/types/types.go
@@ -408,6 +408,7 @@ type Nameserver struct {
 //is-multiple:true
 //test:ok:use_backend test if TRUE
 //test:ok:use_backend test if TRUE # deny
+//test:ok:use_backend test # deny
 //test:fail:use_backend
 type UseBackend struct {
 	Name     string


### PR DESCRIPTION
When parsing a use_backend the condition could be omitted
(https://github.com/haproxy/haproxy/blob/master/doc/configuration.txt#L10409)