### PR TITLE
Add JSON output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/haproxytech/config-parser
 
 go 1.12
+
+require github.com/Jeffail/gabs/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/Jeffail/gabs/v2 v2.1.0 h1:6dV9GGOjoQgzWTQEltZPXlJdFloxvIq7DwqgxMCbq30=
+github.com/Jeffail/gabs/v2 v2.1.0/go.mod h1:xCn81vdHKxFUuWWAaD5jCTQDNPBMh5pPs9IJ+NcziBI=


### PR DESCRIPTION
This adds the ability to output JSON using .JSON() just as you would .String(). 

I've tested this on a number of configs I found in the wild. It seems to export cleanly for everything I have found. 

[Here's one example config](https://gist.githubusercontent.com/johnsusek/6a87042ce7b2f68037db0885df7627b0/raw/f3768d0df3aebad32e6b3c276adea5d900d4881e/gistfile1.txt) I found online, and below is the JSON output from it:


```json
{
  "backend": {
    "static": {
      "balance": "roundrobin",
      "server": {
        "media1": "media1 check port 80",
        "media2": "media2 check port 80"
      }
    },
    "www": {
      "balance": "roundrobin",
      "server": {
        "load1": "localhost:8080 backup",
        "www1": "www1 check port 80",
        "www2": "www2 check port 80",
        "www3": "www3 check port 80"
      }
    }
  },
  "default": {
    "clitimeout": 50000,
    "contimeout": 5000,
    "log": "global",
    "maxconn": 2000,
    "mode": "http",
    "option": [
      "httplog",
      "redispatch",
      "dontlognull",
      "httpchk"
    ],
    "retries": 3,
    "srvtimeout": 50000
  },
  "frontend": {
    "http": {
      "acl": {
        "host_static": "hdr_beg(host) -i static",
        "url_static": "path_beg /static"
      },
      "bind": "0.0.0.0:80",
      "default_backend": "www",
      "option": "http-server-close",
      "use_backend": {
        "static": [
          "if host_static",
          "if url_static"
        ]
      }
    }
  },
  "global": {
    "daemon": true,
    "group": "haproxy",
    "maxconn": 4096,
    "user": "haproxy"
  },
  "listen": {
    "stats": {
      "bind": ":1936",
      "mode": "http",
      "stats": "enable"
    }
  }
}
```
