### PR TITLE
MINOR: log, errorfile: use less memory

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -18,12 +18,6 @@ package common
 
 import "strings"
 
-func AddToBoolMap(data map[string]bool, items ...string) {
-	for _, item := range items {
-		data[item] = true
-	}
-}
-
 //StringSplitIgnoreEmpty while spliting, removes empty items
 func StringSplitIgnoreEmpty(s string, separators ...rune) []string {
 	f := func(c rune) bool {

--- a/parsers/errorfile.go
+++ b/parsers/errorfile.go
@@ -24,17 +24,26 @@ import (
 	"github.com/haproxytech/config-parser/v2/types"
 )
 
+var errorFileAllowedCode = map[string]struct{}{
+	"200": struct{}{},
+	"400": struct{}{},
+	"403": struct{}{},
+	"405": struct{}{},
+	"408": struct{}{},
+	"425": struct{}{},
+	"429": struct{}{},
+	"500": struct{}{},
+	"502": struct{}{},
+	"503": struct{}{},
+	"504": struct{}{},
+}
+
 type ErrorFile struct {
-	data        []types.ErrorFile
-	allowedCode map[string]bool
+	data []types.ErrorFile
 }
 
 func (l *ErrorFile) Init() {
 	l.data = []types.ErrorFile{}
-	l.allowedCode = map[string]bool{}
-	common.AddToBoolMap(l.allowedCode,
-		"200", "400", "403", "405", "408", "425", "429",
-		"500", "502", "503", "504")
 }
 
 func (l *ErrorFile) parse(line string, parts []string, comment string) (*types.ErrorFile, error) {
@@ -46,7 +55,7 @@ func (l *ErrorFile) parse(line string, parts []string, comment string) (*types.E
 		Comment: comment,
 	}
 	code := parts[1]
-	if _, ok := l.allowedCode[code]; !ok {
+	if _, ok := errorFileAllowedCode[code]; !ok {
 		return errorfile, nil
 	}
 	errorfile.Code = code

--- a/parsers/log.go
+++ b/parsers/log.go
@@ -26,21 +26,31 @@ import (
 	"github.com/haproxytech/config-parser/v2/types"
 )
 
+var logAllowedFacitlites = map[string]struct{}{
+	"kern": struct{}{}, "user": struct{}{}, "mail": struct{}{}, "daemon": struct{}{},
+	"auth": struct{}{}, "syslog": struct{}{}, "lpr": struct{}{}, "news": struct{}{},
+	"uucp": struct{}{}, "cron": struct{}{}, "auth2": struct{}{}, "ftp": struct{}{},
+	"ntp": struct{}{}, "audit": struct{}{}, "alert": struct{}{}, "cron2": struct{}{},
+	"local0": struct{}{}, "local1": struct{}{}, "local2": struct{}{}, "local3": struct{}{},
+	"local4": struct{}{}, "local5": struct{}{}, "local6": struct{}{}, "local7": struct{}{},
+}
+var logAllowedLevels = map[string]struct{}{
+	"emerg":   struct{}{},
+	"alert":   struct{}{},
+	"crit":    struct{}{},
+	"err":     struct{}{},
+	"warning": struct{}{},
+	"notice":  struct{}{},
+	"info":    struct{}{},
+	"debug":   struct{}{},
+}
+
 type Log struct {
-	data              []types.Log
-	allowedLevels     map[string]bool
-	allowedFacitlites map[string]bool
+	data []types.Log
 }
 
 func (l *Log) Init() {
 	l.data = []types.Log{}
-	l.allowedFacitlites = map[string]bool{}
-	l.allowedLevels = map[string]bool{}
-	common.AddToBoolMap(l.allowedFacitlites,
-		"kern", "user", "mail", "daemon", "auth", "syslog", "lpr", "news",
-		"uucp", "cron", "auth2", "ftp", "ntp", "audit", "alert", "cron2",
-		"local0", "local1", "local2", "local3", "local4", "local5", "local6", "local7")
-	common.AddToBoolMap(l.allowedLevels, "emerg", "alert", "crit", "err", "warning", "notice", "info", "debug")
 }
 
 func (l *Log) parse(line string, parts []string, comment string) (*types.Log, error) {
@@ -85,7 +95,7 @@ func (l *Log) parse(line string, parts []string, comment string) (*types.Log, er
 		return log, &errors.ParseError{Parser: "Log", Line: line}
 	}
 	facility := parts[currIndex]
-	if _, ok := l.allowedFacitlites[facility]; !ok {
+	if _, ok := logAllowedFacitlites[facility]; !ok {
 		return log, &errors.ParseError{Parser: "Log", Line: line}
 	}
 	log.Facility = facility
@@ -95,7 +105,7 @@ func (l *Log) parse(line string, parts []string, comment string) (*types.Log, er
 		return log, nil
 	}
 	level := parts[currIndex]
-	if _, ok := l.allowedLevels[level]; !ok {
+	if _, ok := logAllowedLevels[level]; !ok {
 		return log, nil
 	}
 	log.Level = level
@@ -105,7 +115,7 @@ func (l *Log) parse(line string, parts []string, comment string) (*types.Log, er
 		return log, nil
 	}
 	level = parts[currIndex]
-	if _, ok := l.allowedLevels[level]; !ok {
+	if _, ok := logAllowedLevels[level]; !ok {
 		return log, nil
 	}
 	log.MinLevel = level


### PR DESCRIPTION
since parsing data is sequential,
we can avoid instantiating some variables and
use global constants.