### PR TITLE
BUG/MINOR: fix error while parsing pgsql-check in defaults section

### DIFF
--- a/section-parsers.go
+++ b/section-parsers.go
@@ -94,7 +94,7 @@ func getDefaultParser() *Parsers {
 		&simple.Option{Name: "ldap-check"},
 		&parsers.OptionMysqlCheck{},
 		&simple.Option{Name: "abortonclose"},
-		&simple.Option{Name: "pgsql-check"},
+		&parsers.OptionPgsqlCheck{},
 		&simple.Option{Name: "tcp-check"},
 		&simple.Option{Name: "redis-check"},
 		&parsers.OptionHttpchk{},


### PR DESCRIPTION
Hi, I am getting an error in dataplane api. Please refer [#129](https://github.com/haproxytech/dataplaneapi/issues/129) for details

> {"code":500,"message":"interface conversion: common.ParserData is *types.OptionPgsqlCheck, not *types.SimpleOption: /home/local/adarsh/go/pkg/mod/github.com/haproxytech/client-native/v2@v2.1.0/configuration/configuration.go:625 parseField"}