### PR TITLE
BUG/MINOR: Correctly hanlde IPv6 addresses when parsing <ip>:<port> pair

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -124,3 +124,19 @@ func SplitRequest(parts []string) (command, condition []string) { //nolint:nonam
 	condition = parts[index:]
 	return command, condition
 }
+
+// CutRight slices string around the last occurrence of sep returning the text
+// before and after sep. The found result reports whether sep appears in s. If
+// sep does not appear in s, cut returns s, "", false.
+func CutRight(s, sep string) (before, after string, found bool) {
+	pos := strings.LastIndex(s, sep)
+	if pos < 0 {
+		before = s
+		found = false
+	} else {
+		before = s[:pos]
+		after = s[pos+len(sep):]
+		found = true
+	}
+	return before, after, found
+}

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -53,3 +53,72 @@ func TestStringSplitWithCommentIgnoreEmpty(t *testing.T) {
 		})
 	}
 }
+
+func TestCutRight(t *testing.T) {
+	tests := []struct {
+		name   string
+		s      string
+		sep    string
+		before string
+		after  string
+		found  bool
+	}{
+		{
+			name:   "simple",
+			s:      "ab:cd:ef",
+			sep:    ":",
+			before: "ab:cd",
+			after:  "ef",
+			found:  true,
+		},
+		{
+			name:   "multi-characters-sep",
+			s:      "ab:-:cd:-:ef",
+			sep:    ":-:",
+			before: "ab:-:cd",
+			after:  "ef",
+			found:  true,
+		},
+		{
+			name:   "sep-at-start",
+			s:      ":abcd",
+			sep:    ":",
+			before: "",
+			after:  "abcd",
+			found:  true,
+		},
+		{
+			name:   "sep-at-end",
+			s:      "abcd:",
+			sep:    ":",
+			before: "abcd",
+			after:  "",
+			found:  true,
+		},
+		{
+			name:   "no-sep",
+			s:      "abcd",
+			sep:    ":",
+			before: "abcd",
+			after:  "",
+			found:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before, after, found := CutRight(tt.s, tt.sep)
+			if before != tt.before {
+				t.Errorf("Part before separator doesn't match expected: %q != %q", before, tt.before)
+				return
+			}
+			if after != tt.after {
+				t.Errorf("Part after separator doesn't match expected: %q != %q", after, tt.after)
+				return
+			}
+			if found != tt.found {
+				t.Errorf("Found result doesn't match expected: %v != %v", found, tt.found)
+				return
+			}
+		})
+	}
+}

--- a/parsers/mailer.go
+++ b/parsers/mailer.go
@@ -32,12 +32,12 @@ type Mailer struct {
 
 func (l *Mailer) parse(line string, parts []string, comment string) (*types.Mailer, error) {
 	if len(parts) > 2 {
-		adr := common.StringSplitIgnoreEmpty(parts[2], ':')
-		if len(adr) >= 2 {
-			if port, err := strconv.ParseInt(adr[1], 10, 64); err == nil {
+		adr, p, found := common.CutRight(parts[2], ":")
+		if found && len(adr) > 0 {
+			if port, err := strconv.ParseInt(p, 10, 64); err == nil {
 				return &types.Mailer{
 					Name:    parts[1],
-					IP:      adr[0],
+					IP:      adr,
 					Port:    port,
 					Comment: comment,
 				}, nil

--- a/parsers/peer.go
+++ b/parsers/peer.go
@@ -32,12 +32,12 @@ type Peer struct {
 
 func (l *Peer) parse(line string, parts []string, comment string) (*types.Peer, error) {
 	if len(parts) > 2 {
-		adr := common.StringSplitIgnoreEmpty(parts[2], ':')
-		if len(adr) >= 2 {
-			if port, err := strconv.ParseInt(adr[1], 10, 64); err == nil {
+		adr, p, found := common.CutRight(parts[2], ":")
+		if found && len(adr) > 0 {
+			if port, err := strconv.ParseInt(p, 10, 64); err == nil {
 				return &types.Peer{
 					Name:    parts[1],
-					IP:      adr[0],
+					IP:      adr,
 					Port:    port,
 					Comment: comment,
 				}, nil

--- a/parsers/server-template.go
+++ b/parsers/server-template.go
@@ -26,10 +26,10 @@ func (h *ServerTemplate) parse(line string, parts []string, comment string) (*ty
 	data.NumOrRange = parts[2]
 	data.Comment = comment
 
-	address := common.StringSplitIgnoreEmpty(parts[3], ':')
-	if len(address) == 2 {
-		if port, err := strconv.ParseInt(address[1], 10, 64); err == nil {
-			data.Fqdn = address[0]
+	address, p, found := common.CutRight(parts[3], ":")
+	if found {
+		if port, err := strconv.ParseInt(p, 10, 64); err == nil {
+			data.Fqdn = address
 			data.Port = port
 		}
 	} else {


### PR DESCRIPTION
Currently parser split <ip>:<port> pair by the first colon which leads to incorrect result in case of IPv6, this pull request interprets the part after the last colon as a port and everything before as an address.

Closes: #50